### PR TITLE
Added capability for continuous stream from orderbook updates

### DIFF
--- a/sdks/java/extensions/timeseries/src/test/java/org/apache/beam/sdk/extensions/timeseries/fs/NaiveOrderBookTest.java
+++ b/sdks/java/extensions/timeseries/src/test/java/org/apache/beam/sdk/extensions/timeseries/fs/NaiveOrderBookTest.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.TreeMap;
 import org.apache.beam.sdk.extensions.timeseries.fs.example.NaiveOrderBook;
 import org.apache.beam.sdk.extensions.timeseries.fs.example.Order;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;


### PR DESCRIPTION
An important use case for building orderbooks is to have *all* of the orderbook updates for downstream processing. Adding in a flag to indicate that the Orderbook should be passed downstream in the TickStream.java.

Note that significant filtering will happen downstream, i.e., the orderbook can track the latest changes and what level in the book it impacts so that downstream can filter out changes that are insignificant.